### PR TITLE
Write to event bus when cart is created or updated

### DIFF
--- a/aws/cloudformation-templates/services/service/service.yaml
+++ b/aws/cloudformation-templates/services/service/service.yaml
@@ -300,6 +300,8 @@ Resources:
             - Name: SEGMENT_WRITE_KEY
               ValueFrom: !Sub 'arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/retaildemostore-segment-write-key'
           Environment:
+            - Name: AWS_REGION
+              Value: !Ref AWS::Region
             - Name: PERSONALIZE_CAMPAIGN_ARN
               Value: !Ref EnvPersonalizeCampaignArn          
             - Name: SEARCH_CAMPAIGN_ARN

--- a/src/carts/Dockerfile
+++ b/src/carts/Dockerfile
@@ -2,6 +2,9 @@ FROM public.ecr.aws/s5z3t2n9/golang:1.11-alpine AS build
 WORKDIR /src/
 COPY src/carts-service/*.* /src/
 RUN apk add --no-cache git
+
+RUN go get -u github.com/aws/aws-sdk-go/aws/session
+RUN go get -u github.com/aws/aws-sdk-go/service/eventbridge
 RUN go get -u github.com/gorilla/mux
 RUN go get -u gopkg.in/yaml.v2
 RUN CGO_ENABLED=0 go build -o /bin/carts-service

--- a/src/carts/src/carts-service/cart.go
+++ b/src/carts/src/carts-service/cart.go
@@ -10,9 +10,6 @@ type Cart struct {
 	Items    CartItems `json:"items" yaml:"items"`
 }
 
-// Carts Array
-type Carts []Cart
-
 // CartItem Struct
 type CartItem struct {
 	ProductID string  `json:"product_id" yaml:"product_id"`

--- a/src/carts/src/carts-service/handlers.go
+++ b/src/carts/src/carts-service/handlers.go
@@ -6,7 +6,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/aws/aws-sdk-go/aws/session"
 	"io"
 	"io/ioutil"
 	"log"
@@ -14,6 +13,7 @@ import (
 	"os"
 	"path"
 
+	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/eventbridge"
 	"github.com/gorilla/mux"
 )

--- a/src/carts/src/carts-service/main.go
+++ b/src/carts/src/carts-service/main.go
@@ -6,9 +6,15 @@ package main
 import (
 	"log"
 	"net/http"
+	"os"
 )
 
 func main() {
+	port, exists := os.LookupEnv("PORT")
+	if !exists {
+		port = "80"
+	}
+
 	router := NewRouter()
-	log.Fatal(http.ListenAndServe(":80", router))
+	log.Fatal(http.ListenAndServe(":" + port, router))
 }

--- a/src/carts/src/carts-service/repository.go
+++ b/src/carts/src/carts-service/repository.go
@@ -9,41 +9,34 @@ import (
 
 var currentID int
 
-var carts Carts = Carts{}
+var carts = map[string]Cart{}
 
-func init() {
-}
 
 // RepoFindCartByID Function
 func RepoFindCartByID(id string) Cart {
-	for _, t := range carts {
-		if t.ID == id {
-			return t
-		}
-	}
-	// return empty Cart if not found
-	return Cart{}
+	cart := carts[id]
+	return cart
 }
 
 // RepoUpdateCart Function
-func RepoUpdateCart(t Cart) Cart {
+func RepoUpdateCart(id string, cart Cart) Cart {
+	_, ok := carts[id]
 
-	for i := 0; i < len(carts); i++ {
-		c := &carts[i]
-		if c.ID == t.ID {
-			c.Items = t.Items
-			return RepoFindCartByID(t.ID)
-		}
+	if !ok {
+		// return empty Cart if not found
+		return Cart{}
 	}
 
-	// return empty Cart if not found
-	return Cart{}
+	cart.ID = id
+	carts[id] = cart
+
+	return cart
 }
 
 // RepoCreateCart Function
 func RepoCreateCart(t Cart) Cart {
 	currentID++
 	t.ID = strconv.Itoa(currentID)
-	carts = append(carts, t)
-	return RepoFindCartByID(t.ID)
+	carts[t.ID] = t
+	return t
 }

--- a/src/carts/src/carts-service/repository.go
+++ b/src/carts/src/carts-service/repository.go
@@ -14,7 +14,10 @@ var carts = map[string]Cart{}
 
 // RepoFindCartByID Function
 func RepoFindCartByID(id string) Cart {
-	cart := carts[id]
+	cart, ok := carts[id]
+	if !ok {
+		return Cart{}
+	}
 	return cart
 }
 


### PR DESCRIPTION
*Description of changes:*

This change makes the Cart Service publish an event to Eventridge when the cart is created or updated. There was also a bug that meant the `CartUpdate` function, called by the `/carts/id/{cartID}` route, did not update the cart as the id was not being passed to the function. I've also changed the implementation to use a hashmap rather than an array so we no longer have to iterate the data structure to find elements.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
